### PR TITLE
Output slighty-more idiomatic C

### DIFF
--- a/callback-heaven.lisp
+++ b/callback-heaven.lisp
@@ -232,18 +232,20 @@ Note that this memory is not further managed!"
 
 (defun emit-api-function-prototype (api-function stream)
   (flet ((format-arg (arg-and-type)
-           (format nil "~A ~A"
+           (format nil "~A~:[~; ~]~A"
                    (type-name-to-foreign (second arg-and-type))
+                   (%need-space-p arg-and-type)
                    (cffi:translate-name-to-foreign (first arg-and-type) nil))))
-    (format stream "~A ~A(~{~A~^, ~})"
+    (format stream "~A~:[ ~;~]~A(~{~A~^, ~})"
             (type-name-to-foreign (api-function-return-type api-function))
+            (listp (api-function-return-type api-function))
             (api-function-c-name api-function)
             (mapcar #'format-arg (api-function-arguments api-function)))))
 
 (defun emit-api-function-header (ctrans stream)
   ;; Emit the function index setter.
   (terpri stream)
-  (format stream "void ~A(void** functions);~%"
+  (format stream "void ~A(void **functions);~%"
           (function-index-setter-function-name ctrans))
   
   ;; Emit all of the API prototypes.

--- a/utilities.lisp
+++ b/utilities.lisp
@@ -55,6 +55,11 @@
     (:boolean "int")
     (:string "char*")))
 
+(defun %need-space-p (name)
+  (and (second name)
+       (not (typep (second name) 'list))
+       (not (eq ':pointer (second name)))))
+
 (defun type-name-to-foreign (name)
   (labels ((simple-name-p (name)
              (symbolp name))
@@ -69,8 +74,9 @@
       ((listp name) (case (first name)
                       ((:struct) (format nil "struct ~A"
                                          (cffi:translate-name-to-foreign (second name) nil)))
-                      ((:pointer) (format nil "~A *"
-                                          (type-name-to-foreign (second name))))
+                      ((:pointer) (format nil "~A~:[~; ~]*"
+                                          (type-name-to-foreign (second name))
+                                          (%need-space-p name)))
                       ((:function)
                        (destructuring-bind (return-type &rest arg-types)
                            (rest name)


### PR DESCRIPTION
Prior to this, pointers would be printed sometimes like `void* *functions`, or `void ** functions`, or maybe `void** functions`. This makes all pointer types print like `void **functions`.