### PR TITLE
Cleanups heaven

### DIFF
--- a/callback-heaven.lisp
+++ b/callback-heaven.lisp
@@ -299,9 +299,9 @@ Note that this memory is not further managed!"
 (defun emit-h-file-contents (ctrans stream)
   (let ((guard (format nil "GROUP_~A_HEADER_GUARD"
                        (string-upcase
-                        (symbol-name
-                         (api-group-name
-                          (c-space-translation-api-group ctrans)))))))
+                        (cffi:translate-name-to-foreign
+                         (api-group-name (c-space-translation-api-group ctrans))
+                         nil)))))
     (format stream "#ifndef ~A~%" guard)
     (format stream "#define ~A~%~%" guard)
     (emit-includes stream)

--- a/callback-heaven.lisp
+++ b/callback-heaven.lisp
@@ -102,7 +102,7 @@ For example:
   (check-type c-name (or null string))
   (when (null c-name)
     (setf c-name (cffi:translate-name-to-foreign name nil)))
-  
+
   (let* ((api-group (api-group group-name))
          (current-api-function (api-group-function api-group name))
          (callback-name (if current-api-function
@@ -126,7 +126,7 @@ For example:
            (declare (inline ,name)
                     (ignorable (function ,name)))
            ,@body))
-       
+
        (setf (api-group-function (api-group ',group-name) ',name)
              (make-api-function :name ',name
                                 :callback-name ',callback-name
@@ -134,7 +134,7 @@ For example:
                                 :c-name ,c-name
                                 :return-type ',return-type
                                 :arguments ',args-and-types))
-       
+
        ;; Neither CCL nor LispWorks need an update here, since the
        ;; pointers seem to persist across redefinitions. It's not
        ;; unsafe to do it anyway, however.
@@ -145,7 +145,7 @@ For example:
        (let ((ctrans (gethash (api-group ',group-name) *api-group-translations*)))
          (when ctrans
            (update-foreign-function-index ctrans)))
-       
+
        ',name)))
 
 ;;;;;;;;;;;;;;;;;;;;;;; TRAMPOLINE GENERATION ;;;;;;;;;;;;;;;;;;;;;;;;
@@ -247,7 +247,7 @@ Note that this memory is not further managed!"
   (terpri stream)
   (format stream "void ~A(void **functions);~%"
           (function-index-setter-function-name ctrans))
-  
+
   ;; Emit all of the API prototypes.
   (loop :with api-group := (c-space-translation-api-group ctrans)
         :for fname :across (c-space-translation-index-translations ctrans)
@@ -331,5 +331,5 @@ The C file may be compiled either as a shared library or as a part of a larger s
                                    :if-exists if-exists)
       (format stream "#include \"~A\"~%~%" (file-namestring h-file))
       (emit-c-file-contents ctrans stream))
-    
+
     (values c-file h-file)))

--- a/callback-heaven.lisp
+++ b/callback-heaven.lisp
@@ -306,7 +306,7 @@ Note that this memory is not further managed!"
     (format stream "#define ~A~%~%" guard)
     (emit-includes stream)
     (emit-api-function-header ctrans stream)
-    (format stream "~&~%~%#endif /* ~A */" guard)))
+    (format stream "~&~%~%#endif /* ~A */~%" guard)))
 
 ;;; Helper for EMIT-LIBRARY-FILES.
 (defun emit-c-file-contents (ctrans stream)

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,4 @@
+*.o
+*.so
+*.dylib
+*.fasl

--- a/example/example.h
+++ b/example/example.h
@@ -5,7 +5,7 @@
 #include <stddef.h>
 
 
-void set_function_index_group_example(void** functions);
+void set_function_index_group_example(void **functions);
 
 int add(int a, int b);
 

--- a/example/example.lisp
+++ b/example/example.lisp
@@ -54,7 +54,7 @@
 ;;
 ;; (defun set-group-example-index ()
 ;;   (%set-function-index-group-example
-;;    (callback-heaven::c-space-translation-function-index *ctrans*)))
+;;    (c-space-translation-function-index *ctrans*)))
 ;;
 ;; (set-group-example-index)
 

--- a/example/example.lisp
+++ b/example/example.lisp
@@ -25,7 +25,7 @@
 
 ;; If your above API changes, you need to re-emit the C-API with the
 ;; following
-;; 
+;;
 ;;   (emit-library-files *ctrans* "example.c" "example.h")
 ;;
 ;; Then you will need to recompile the shared library
@@ -34,12 +34,12 @@
 
 ;; To load the shared library, make sure you are in the same directory
 ;; as the library and load it with:
-;; 
+;;
 ;; (cffi:define-foreign-library example
 ;;   (:darwin "libexample.dylib")
 ;;   (:unix   "libexample.so")
 ;;   (t (:default "libexample")))
-;; 
+;;
 ;; (cffi:use-foreign-library example)
 
 ;; CALLBACK-HEAVEN will also define a function (in the .c/.h files)
@@ -47,24 +47,24 @@
 ;; function will take in pointers to our defined lisp functions
 ;; (above) and set-up the trampoline structure in C.  We need to
 ;; inform CFFI of its existence:
-;; 
+;;
 ;; (cffi:defcfun ("set_function_index_group_example" %set-function-index-group-example)
 ;;     :void
 ;;   (functions (:pointer (:pointer :void))))
-;; 
+;;
 ;; (defun set-group-example-index ()
 ;;   (%set-function-index-group-example
 ;;    (callback-heaven::c-space-translation-function-index *ctrans*)))
-;; 
+;;
 ;; (set-group-example-index)
 
 ;; In main.c we defined a function call_me_from_lisp, that will act as
 ;; our go-between.  Tell CFFI of its existence,
-;; 
+;;
 ;; (cffi:defcfun ("call_me_from_lisp" %call-me-from-lisp) :void)
 ;;
 ;; and invoke it with:
-;; 
+;;
 ;; CALLBACK-HEAVEN-EXAMPLES> (%call-me-from-lisp)
 ;; Factorial 5 = 120
 ;; NIL

--- a/package.lisp
+++ b/package.lisp
@@ -8,6 +8,7 @@
    #:define-api-group                   ; MACRO
    #:define-api-function                ; MACRO
    #:compute-c-space-translation        ; FUNCTION
+   #:c-space-translation-function-index ; FUNCTION
    #:emit-library-files                 ; FUNCTION
    #:api-group
    )


### PR DESCRIPTION
Small collection of little cleanups and whatnot.

- `M-x whitespace-cleanup`
- Export `C-SPACE-TRANSLATION-FUNCTION-INDEX`
- Ensure header files are newline terminated
  This avoids a compiler warning (`-Wnewline-eof`) when compiling with `-Wall -Wextra`
- Translate `API-GROUP-NAME` to a foreign name for header guard
   Otherwise, hyphens in a snake-case lisp symbol name get printed as-is and the C preprocessor gets confused.
- Add example/.gitignore
