### PR TITLE
Emit documentation strings for API functions and groups

### DIFF
--- a/callback-heaven.asd
+++ b/callback-heaven.asd
@@ -6,7 +6,7 @@
   :description "A framework for calling Lisp from C."
   :author "Robert Smith <robert@stylewarning.com>"
   :license "BSD 3-clause (See LICENSE.txt)"
-  :depends-on (#:cffi #:alexandria)
+  :depends-on (#:cffi #:alexandria #:uiop)
   :serial t
   :components ((:file "package")
                (:file "utilities")

--- a/example/Makefile
+++ b/example/Makefile
@@ -32,4 +32,4 @@ test: libexample.$(SOEXT)
 		--quit
 
 clean:
-	rm -f *.o *.$(SOEXT)
+	rm -f *.o *.$(SOEXT) example.[ch]

--- a/example/example.h
+++ b/example/example.h
@@ -1,3 +1,8 @@
+/**
+ * @file example.h
+ *
+ * An example group.
+ */
 #ifndef GROUP_EXAMPLE_HEADER_GUARD
 #define GROUP_EXAMPLE_HEADER_GUARD
 
@@ -5,8 +10,18 @@
 #include <stddef.h>
 
 
+/** Return the integer a + b. */
 int add(int a, int b);
 
+/**
+ * Print |n|! on standard output.
+ *
+ * The complete output will look something like
+ *
+ *     Factorial 5 = 120
+ *
+ * @param n the integer whose absolute value will be used to compute the factorial.
+ */
 void print_factorial(int n);
 
 

--- a/example/example.lisp
+++ b/example/example.lisp
@@ -7,12 +7,29 @@
 ;; First define your API group, and its API functions.
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (define-api-group example))
+  (define-api-group example
+    ;; This documentation string will be included at the top of the .h
+    ;; file that is generated for this API-GROUP. Here, we show an
+    ;; example of a doxygen @file directive, but there is no requirement
+    ;; to use doxygen syntax. CALLBACK-HEAVEN simply treats these as an
+    ;; opaque string and emits them between C-style comment delimiters,
+    ;; beginning with /** and ending with */.
+    "@file example.h
+
+An example group."))
 
 (define-api-function (add example) :int ((a :int) (b :int))
+  "Return the integer a + b."
   (ldb '#.(byte 32 0) (+ a b)))
 
 (define-api-function (print-factorial example) :void ((n :int))
+  "Print |n|! on standard output.
+
+The complete output will look something like
+
+    Factorial 5 = 120
+
+@param n the integer whose absolute value will be used to compute the factorial."
   (flet ((factorial (n)
            (let ((result 1))
              (loop :for i :from 1 :to n :do


### PR DESCRIPTION
Allow the caller to provide documentation strings in `define-api-group` and `define-api-function`, and then include them when emitting the `.h` file.

Whether it's better to include these in the`.c` or `.h` files is open to debate. Some users might prefer the comments to go in the `.c` files, but in cases where you are only distributing the `.h` files, that makes more sense. It could be made configurable, but I didn't want to gunk up the `emit-api-files` interface with even more optional keyword args, so I went with unconditionally sticking them in the `.h` file for now.

Likewise, you could imagine someone wanting to configure the exact comment prefix / suffix (e.g. doxygen supports various conventions), but I decided to KISS.
