### PR TITLE
Don't emit the function index setter decl in the header file

### DIFF
--- a/callback-heaven.lisp
+++ b/callback-heaven.lisp
@@ -237,11 +237,6 @@ Note that this memory is not further managed!"
             (mapcar #'format-arg (api-function-arguments api-function)))))
 
 (defun emit-api-function-header (ctrans stream)
-  ;; Emit the function index setter.
-  (terpri stream)
-  (format stream "void ~A(void **functions);~%"
-          (function-index-setter-function-name ctrans))
-
   ;; Emit all of the API prototypes.
   (loop :with api-group := (c-space-translation-api-group ctrans)
         :for fname :across (c-space-translation-index-translations ctrans)

--- a/example/example.h
+++ b/example/example.h
@@ -5,8 +5,6 @@
 #include <stddef.h>
 
 
-void set_function_index_group_example(void **functions);
-
 int add(int a, int b);
 
 void print_factorial(int n);


### PR DESCRIPTION
This function needs to have external linkage so it can be called via `CFFI:DEFCFUN`, but it is not really intended to be called from C by a user of the generated API, and thus is potentially confusing to include it in the header file.